### PR TITLE
ResultsReader now yields ResultsFieldOrder objects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,9 +155,19 @@ $results = new Splunk_ResultsReader($resultsXmlString);
 // Process results
 foreach ($results as $result)
 {
-	if (is_array($result))
+    if ($result instanceof Splunk_ResultsFieldOrder)
     {
-        // Process a normal result
+        // Process the field order
+        print "FIELDS: " . implode(',', $result->getFieldNames()) . "\r\n";
+    }
+    else if ($result instanceof Splunk_ResultsMessage)
+    {
+        // Process a message
+        print "[{$result->getType()}] {$result->getText()}\r\n";
+    }
+    else if (is_array($result))
+    {
+        // Process a row
         print "{\r\n";
         foreach ($result as $field => $valueOrValues)
         {
@@ -174,10 +184,9 @@ foreach ($results as $result)
         }
         print "}\r\n";
     }
-    else if ($result instanceof Splunk_ResultsMessage)
+    else
     {
-        // Process a message
-        print "[{$result->getType()}] {$result->getText()}\r\n";
+        // Ignore unknown result type
     }
 }
 ```
@@ -285,18 +294,27 @@ $results = new Splunk_ResultsReader($resultsXmlString);
 // Process results
 foreach ($results as $result)
 {
-	if (is_array($result))
+    if ($result instanceof Splunk_ResultsFieldOrder)
     {
-        // Process a normal result
-        foreach ($result as $field => $valueOrValues)
-        {
-            // ...
-        }
+        // Process the field order
+        // ...
     }
     else if ($result instanceof Splunk_ResultsMessage)
     {
         // Process a message
         print "[{$result->getType()}] {$result->getText()}\r\n";
+    }
+	else if (is_array($result))
+    {
+        // Process a row
+        foreach ($result as $field => $valueOrValues)
+        {
+            // ...
+        }
+    }
+    else
+    {
+        // Ignore unknown result type
     }
 }
 ```

--- a/Splunk/ResultsFieldOrder.php
+++ b/Splunk/ResultsFieldOrder.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright 2012 Splunk, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"): you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Represents a statement of which fields will be returned in a results stream,
+ * and what their relative ordering is.
+ * 
+ * @package Splunk
+ * @see Splunk_ResultsReader
+ */
+class Splunk_ResultsFieldOrder
+{
+    private $fieldNames;
+    
+    public function __construct($fieldNames)
+    {
+        $this->fieldNames = $fieldNames;
+    }
+    
+    /**
+     * @return array    A ordered list of the field names that will be occur
+     *                  in the results stream.
+     */
+    public function getFieldNames()
+    {
+        return $this->fieldNames;
+    }
+}

--- a/tests/ResultsReaderTest.php
+++ b/tests/ResultsReaderTest.php
@@ -23,6 +23,10 @@ class ResultsReaderTest extends SplunkTest
     {
         $xmlText = file_get_contents('./tests/data/simpleSearchResults.xml');
         $expectedResults = array(
+            new Splunk_ResultsFieldOrder(array(
+                'series',
+                'sum(kb)',
+            )),
             new Splunk_ResultsMessage('DEBUG', 'base lispy: [ AND ]'),
             new Splunk_ResultsMessage('DEBUG', 'search context: user="admin", app="search", bs-pathname="/some/path"'),
             array(
@@ -72,6 +76,10 @@ class ResultsReaderTest extends SplunkTest
 </results>
 ");
         $expectedResults = array(
+            new Splunk_ResultsFieldOrder(array(
+                'series',
+                'sum(kb)',
+            )),
             array(
                 'series' => 'twitter',
                 'sum(kb)' => '14372242.758775',
@@ -98,6 +106,10 @@ class ResultsReaderTest extends SplunkTest
 </results>
 ");
         $expectedResults = array(
+            new Splunk_ResultsFieldOrder(array(
+                'series',
+                'sum(kb)',
+            )),
             new Splunk_ResultsMessage('DEBUG', 'base lispy: [ AND ]'),
         );
         
@@ -127,6 +139,9 @@ class ResultsReaderTest extends SplunkTest
 </results>
 ");
         $expectedResults = array(
+            new Splunk_ResultsFieldOrder(array(
+                'values(sourcetype)',
+            )),
             array(
                 'values(sourcetype)' => array(
                     'scheduler',
@@ -161,6 +176,9 @@ class ResultsReaderTest extends SplunkTest
 </results>
 ");
         $expectedResults = array(
+            new Splunk_ResultsFieldOrder(array(
+                '_raw',
+            )),
             array(
                 '_raw' => '07-13-2012 09:27:27.307 -0700 INFO  Metrics - group=search_concurrency, system total, active_hist_searches=0, active_realtime_searches=0',
             ),
@@ -177,6 +195,8 @@ class ResultsReaderTest extends SplunkTest
         
         $this->assertParsedResultsEquals($expectedResults, $xmlText);
     }
+    
+    // === Utility ===
     
     private function assertParsedResultsEquals($expectedResults, $xmlText)
     {


### PR DESCRIPTION
This makes it easy for clients to determine the desired field order in results, especially when there are no rows or when fields are absent in some rows.
