### PR TITLE
Updated SDK name per legal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Splunk PHP SDK Changelog
+# Splunk SDK for PHP Changelog
 
 ## 0.1.1 (preview)
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If you haven't already installed Splunk, download it here:
 For more about installing and running Splunk and system requirements, see
 [Installing & Running Splunk](http://dev.splunk.com/view/SP-CAAADRV). 
 
-Get a copy of the Splunk PHP SDK from [GitHub](https://github.com/) by cloning
+Get a copy of the Splunk SDK for PHP from [GitHub](https://github.com/) by cloning
 into the repository with git:
 
 > git clone https://github.com/splunk/splunk-sdk-php.git

--- a/examples/index.php
+++ b/examples/index.php
@@ -27,7 +27,7 @@ catch (Exception $e)
 <html>
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  <title>Splunk PHP SDK Examples</title>
+  <title>Splunk SDK for PHP Examples</title>
   <link rel="stylesheet" type="text/css" href="shared/style.css" />
 </head>
 <body>

--- a/examples/job.php
+++ b/examples/job.php
@@ -72,7 +72,7 @@ else
 <html>
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  <title>Job | Splunk PHP SDK Examples</title>
+  <title>Job | Splunk SDK for PHP Examples</title>
   <link rel="stylesheet" type="text/css" href="shared/style.css" />
   <style>
     #job-meta {

--- a/examples/list_jobs.php
+++ b/examples/list_jobs.php
@@ -21,7 +21,7 @@ function getJobStatus($job)
 <html>
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  <title>Jobs | Splunk PHP SDK Examples</title>
+  <title>Jobs | Splunk SDK for PHP Examples</title>
   <link rel="stylesheet" type="text/css" href="shared/style.css" />
 </head>
 <body>

--- a/examples/list_saved_searches.php
+++ b/examples/list_saved_searches.php
@@ -7,7 +7,7 @@ require_once 'settings.php';
 <html>
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  <title>Saved Searches | Splunk PHP SDK Examples</title>
+  <title>Saved Searches | Splunk SDK for PHP Examples</title>
   <link rel="stylesheet" type="text/css" href="shared/style.css" />
 </head>
 <body>

--- a/examples/saved_search.php
+++ b/examples/saved_search.php
@@ -103,7 +103,7 @@ else
 <html>
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  <title>Saved Search | Splunk PHP SDK Examples</title>
+  <title>Saved Search | Splunk SDK for PHP Examples</title>
   <link rel="stylesheet" type="text/css" href="shared/style.css" />
   <style>
     input { margin-bottom: .5em; }

--- a/examples/search.php
+++ b/examples/search.php
@@ -9,7 +9,7 @@ $search = array_key_exists('search', $_GET) ? $_GET['search'] : '';
 <html>
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  <title>Search | Splunk PHP SDK Examples</title>
+  <title>Search | Splunk SDK for PHP Examples</title>
   <link rel="stylesheet" type="text/css" href="shared/style.css" />
 </head>
 <body>

--- a/tests/SplunkTest.php
+++ b/tests/SplunkTest.php
@@ -20,7 +20,7 @@ require_once 'Splunk.php';
 require_once 'settings.php';
 
 /**
- * Base class of all unit tests for the Splunk PHP SDK.
+ * Base class of all unit tests for the Splunk SDK for PHP.
  */
 abstract class SplunkTest extends PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
Global change: Splunk PHP SDK to Splunk SDK for PHP.
