### PR TITLE
Disable SSL certificate validation for PHP > 5.6.0

### DIFF
--- a/Splunk/Http.php
+++ b/Splunk/Http.php
@@ -105,6 +105,11 @@ class Splunk_Http
                 'max_redirects' => 0,       // [PHP 5.2] don't follow HTTP 3xx automatically
                 'ignore_errors' => TRUE,    // don't throw exceptions on bad status codes
             ),
+            'ssl' => array(
+                'verify_peer' => FALSE,      // disable SSL certificate validation
+                'verify_peer_name' => FALSE, // disable peer name verification
+                'allow_self_signed' => TRUE, // allow self signed certificates
+            ),
         ));
         
         // NOTE: PHP does not perform certificate validation for HTTPS URLs.


### PR DESCRIPTION
The SSL certificate validation is already disabled when using PHP<5.3.7 as it's configured in cURL options (Http.php:161).
However when PHP>5.3.7 is used, native fopen is used as the http client, and it's assumed that SSL is disabled by default (line 112).

However as of PHP version 5.6.0, the SSL certificate validation is enabled by default (reference: http://php.net/manual/en/context.ssl.php), and this cause user with PHP >= 5.6.0 not to be able to use the sdk library. 

This pull request will fix the issue for these users, by explicitly disable certificate validation in http context.

I have already signed the individual contributor agreement. Thanks in advance for considering the change.